### PR TITLE
Allow the use of Sodium 0.6.0 or newer

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,6 +32,6 @@
     "cloth-config": "*"
   },
   "breaks": {
-    "sodium": "*"
+    "sodium": "<0.6.0"
   }
 }


### PR DESCRIPTION
We added support for modifying the alpha component of vertex colors in terrain rendering. (see [commit](https://github.com/CaffeineMC/sodium-fabric/commit/d61617800141a4d6684bc06a3ec243edba8b4f4b)) This should allow your mod to work correctly with Sodium, and it will prevent older (incompatible) versions of Sodium from being used.